### PR TITLE
Revise user and volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,6 @@ RUN \
 
 COPY /root /
 
-RUN \
-  mkdir /data \
-  && chown -R abc:abc /data
-
 EXPOSE 3000
 
 VOLUME /config
-VOLUME /data

--- a/Readme.md
+++ b/Readme.md
@@ -9,11 +9,6 @@ Docker images are available on [dockerhub](https://hub.docker.com/r/wolkenschieb
 
 ## Docker
 
-### Build
-
-```sh
-docker build --tag wolkenschieber/eclipse-tabnine:latest .
-```
 ### Run 
 
 #### Background
@@ -28,7 +23,6 @@ docker run --detach \
     --shm-size="1gb" \
     wolkenschieber/eclipse-tabnine:latest
 ```
-
 #### Diagnostic
 
 ```sh
@@ -42,35 +36,30 @@ docker run --rm -it \
     wolkenschieber/eclipse-tabnine:latest \
     bash
 ```
+### Pull
+
+```sh
+docker pull wolkenschieber/eclipse-tabnine:latest
+```
+### Build
+
+```sh
+docker build --tag wolkenschieber/eclipse-tabnine:latest .
+```
 
 ## Docker Compose
 
-This project provides a sample [docker-compose.yml](https://github.com/wolkenschieber/eclipse-tabnine/blob/master/docker-compose.yml) file. Please configure the mounted volume as outlined below.
+This project provides a sample [docker-compose.yml](https://github.com/wolkenschieber/eclipse-tabnine/blob/master/docker-compose.yml) file.
 
-### Volumes
-
-#### Creating data volume
-
-The user's id in the image is _911_. Thus the permissions of the mounted volume must be set accordingly:
-```sh
-mkdir -p data/sources \
-    && sudo chown -R 911:911 data \
-    && sudo chmod -R ugo+rwxs data 
-```
-#### Cloning sources
-
-Clone sources via git into directory `/data/sources` via container's Eclipse.
-
-#### Copying sources
-
-Sources should be deployed to `data/sources`. After the deployment the file permissions need to be updated:
-```sh
-sudo chown --reference data -R data/sources
-```
 ### Run
 
 ```sh
 docker compose up -d
+```
+### Pull
+
+```sh
+docker compose pull
 ```
 ### Build
 
@@ -86,6 +75,19 @@ environment:
     - "HTTPS_PROXY=http://proxyhost:8080"      
     - "NO_PROXY=127.0.0.1"
 ```
+
+## Parameters
+
+| Parameter | Function |
+| :----: | --- |
+| `-p 3000` | Eclipse-Tabnine desktop gui. |
+| `-e PUID=1000` | for UserID |
+| `-e PGID=1000` | for GroupID |
+| `-e TZ=Etc/UTC` | specify a timezone to use |
+| `-e ECLIPSE_DEBUG=1` | run Eclipse with program args `-consoleLog -debug` |
+| `-e ECLIPSE_RUN_AS_ROOT=1` | run Eclipse as root |
+| `-v /config` | Users home directory in the container, stores program settings. |
+| `--shm-size=` | This is needed for electron applications to function properly. |
 
 ## Links
 

--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,8 @@ docker build --tag wolkenschieber/eclipse-tabnine:latest .
 
 ```sh
 docker run --detach \
+    -e PUID=1000 \
+    -e PGID=1000 \
     -e TZ=Europe/Berlin \
     -p 3000:3000 \
     --name eclipse-tabnine \
@@ -31,6 +33,8 @@ docker run --detach \
 
 ```sh
 docker run --rm -it \
+    -e PUID=1000 \
+    -e PGID=1000 \
     -e TZ=Europe/Berlin \
     -p 3000:3000 \
     --name eclipse-tabnine \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     container_name: eclipse-tabnine
     shm_size: '1gb'
     environment:
+      - PUID=1000
+      - PGID=1000
       - TZ=Europe/Berlin
     ports:
       - "3000:3000"
@@ -15,11 +17,9 @@ services:
       - eclipse-tabnine
     volumes:
       - config:/config
-      - ${PWD}/data:/data
 
 networks:
   eclipse-tabnine:
-
 
 volumes:
   config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/Berlin
+      - ECLIPSE_DEBUG=0
+      - ECLIPSE_RUN_AS_ROOT=0
     ports:
       - "3000:3000"
     networks:

--- a/root/usr/bin/wrapped-eclipse
+++ b/root/usr/bin/wrapped-eclipse
@@ -1,4 +1,31 @@
 #!/bin/bash
-BIN=/opt/eclipse/eclipse
+BIN='/opt/eclipse/eclipse'
+SUDO='sudo'
 
-${BIN} -data "/config/eclipse/workspace" -consoleLog -debug -clean -vmargs -Duser.home=/config/eclipse/user
+ECLIPSE_WORKSPACE="/config/eclipse/workspace"
+ECLIPSE_USER_DIR="/config/eclipse/user"
+
+COMMAND=''
+
+if [ -z "${ECLIPSE_RUN_AS_ROOT}" ]; then
+    ECLIPSE_RUN_AS_ROOT=0
+fi
+
+if [ "${ECLIPSE_RUN_AS_ROOT}" -eq 1 ]; then
+    COMMAND="${SUDO}"
+fi
+
+COMMAND="${COMMAND} ${BIN} -data ${ECLIPSE_WORKSPACE} -clean"
+
+
+if [ -z "${ECLIPSE_DEBUG}" ]; then
+    ECLIPSE_DEBUG=0
+fi
+
+if [ "${ECLIPSE_DEBUG}" -eq 1 ]; then
+    COMMAND="${COMMAND} -consoleLog -debug"
+fi
+
+COMMAND="${COMMAND} -vmargs -Duser.home=${ECLIPSE_USER_DIR}"
+
+${COMMAND}

--- a/root/usr/bin/wrapped-eclipse
+++ b/root/usr/bin/wrapped-eclipse
@@ -1,4 +1,4 @@
 #!/bin/bash
 BIN=/opt/eclipse/eclipse
 
-${BIN} -data "/data/eclipse/workspace" -consoleLog -debug -clean -vmargs -Duser.home=/data/eclipse/user
+${BIN} -data "/config/eclipse/workspace" -consoleLog -debug -clean -vmargs -Duser.home=/config/eclipse/user


### PR DESCRIPTION
- Handling of volume `/data` cumbersome and error prone. 
- Containers show not run as `root` in default
- Add Eclipse debug environment variable
- Add Eclipse run as root environment variable (Macs 🤨)